### PR TITLE
Fixed iPhone 5 issue with displaying titles

### DIFF
--- a/src/Gallery/gallery.css
+++ b/src/Gallery/gallery.css
@@ -5,6 +5,7 @@
 
 .forge-gallery .tile {
   border-radius: 5px;
+  margin-bottom: 1.8em;
   position: relative;
 }
 
@@ -16,14 +17,15 @@
 }
 
 .forge-gallery .tile .tile-title {
+  bottom: 0;
+  width: calc(100% - 30px);
   background-color: rgba(80, 80, 80, .5);
-  border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
   bottom: 0;
   color: white;
   font-size: 1em;
-  text-shadow: 1px 1px 1px black;
   padding: .6em .8em;
-  position: relative;
-  top: -36px;
+  position: absolute;
+  text-shadow: 1px 1px 1px black;
 }


### PR DESCRIPTION
Hey @jaimerosales I fixed this issue.

It used to be like this:

![2016-11-11 10 37 17 am](https://cloud.githubusercontent.com/assets/1854949/20220390/574334c8-a7fb-11e6-9bcd-e8543d76ccbe.png)


And not it's like this:

![2016-11-11 10 39 39 am](https://cloud.githubusercontent.com/assets/1854949/20220399/5de449ac-a7fb-11e6-935f-534ca1fb3d66.png)
